### PR TITLE
Better highlight for flake8 and signify plugins

### DIFF
--- a/colors/spring-night.vim
+++ b/colors/spring-night.vim
@@ -201,6 +201,15 @@ exe 'hi' 'ALEErrorSign' 'term=NONE' 'guifg=#3a4b5c' 'ctermfg=235' 'guibg=#ab6560
 hi ALEInfoSign term=NONE guibg=#646f7c ctermbg=60
 hi ALEError term=NONE guibg=#ab6560 ctermbg=167
 exe 'hi' 'ALEWarning' 'term=NONE' 'guibg='.s:darkgold_gui 'ctermbg=58'
+hi Flake8_Error term=NONE guifg=#fd8489 ctermfg=210 guibg=#3a4b5c ctermbg=235
+hi Flake8_Warning term=NONE guifg=#f0eaaa ctermfg=229 guibg=#3a4b5c ctermbg=235
+hi Flake8_PyFlake term=NONE guifg=#a8d2eb ctermfg=153 guibg=#3a4b5c ctermbg=235
+hi Flake8_Complexity term=NONE guifg=#a8d2eb ctermfg=153 guibg=#3a4b5c ctermbg=235
+hi Flake8_Naming term=NONE guifg=#a8d2eb ctermfg=153 guibg=#3a4b5c ctermbg=235
+hi SignifySignAdd term=NONE guifg=#a9dd9d ctermfg=150 guibg=#3a4b5c ctermbg=235
+hi SignifySignChange term=NONE guifg=#f0eaaa ctermfg=229 guibg=#3a4b5c ctermbg=235
+hi SignifySignChangeDelete term=NONE guifg=#fedf81 ctermfg=222 guibg=#3a4b5c ctermbg=235
+hi SignifySignDelete term=NONE guifg=#fd8489 ctermfg=210 guibg=#3a4b5c ctermbg=235
 exe 'hi' 'CleverFChar' 'term=NONE' 'guifg='.s:bg_gui 'ctermfg=233' 'guibg=#fd8489' 'ctermbg=210'
 exe 'hi' 'DirvishArg' 'term=NONE' 'guifg=#f0eaaa' 'ctermfg=229' s:bold_attr
 exe 'hi' 'EasyMotionTarget' 'term=NONE' 'guifg=#fd8489' 'ctermfg=210' s:bold_attr

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -748,6 +748,17 @@ fn spring_night_writer<'a, W: io::Write>(out: W) -> Writer<'a, W> {
         Always(fgbg!(ALEInfoSign,           -,          light,        Nothing)),
         Always(fgbg!(ALEError,              -,          mildred,      Nothing)),
         Always(fgbg!(ALEWarning,            -,          darkgold,     Nothing)),
+        Always(fgbg!(Flake8_Error,          red,        bgemphasis,   Nothing)),
+        Always(fgbg!(Flake8_Warning,        yellow,     bgemphasis,   Nothing)),
+        Always(fgbg!(Flake8_PyFlake,        skyblue,    bgemphasis,   Nothing)),
+        Always(fgbg!(Flake8_Complexity,     skyblue,    bgemphasis,   Nothing)),
+        Always(fgbg!(Flake8_Naming,         skyblue,    bgemphasis,   Nothing)),
+        Always(fgbg!(SignifySignAdd,        green,      bgemphasis,   Nothing)),
+        Always(fgbg!(SignifySignChange,     yellow,     bgemphasis,   Nothing)),
+        Always(
+            fgbg!(SignifySignChangeDelete,  gold,       bgemphasis,   Nothing)
+        ),
+        Always(fgbg!(SignifySignDelete,     red,        bgemphasis,   Nothing)),
         Always(fgbg!(CleverFChar,           bg,         red,          Nothing)),
         Always(fgbg!(DirvishArg,            yellow,     -,            Bold)),
         Always(fgbg!(EasyMotionTarget,      red,        -,            Bold)),


### PR DESCRIPTION
Hi, I've added somewhat better colors for the gutter symbols displayed by the two plugins I use often - flake8 and signify. Feel free to merge them to master if you like:

![image](https://user-images.githubusercontent.com/4627919/65628071-ff3ead00-dfd0-11e9-97b1-e4d052f88fd2.png)

![image](https://user-images.githubusercontent.com/4627919/65628226-517fce00-dfd1-11e9-945c-ce758e0c44f7.png)
